### PR TITLE
[fix] GetDirectory error with callback full path

### DIFF
--- a/script.module.codequick/lib/codequick/listing.py
+++ b/script.module.codequick/lib/codequick/listing.py
@@ -6,6 +6,7 @@ from time import strptime, strftime
 import logging
 import os
 import re
+import types
 
 # Fix attemp for
 import _strptime
@@ -636,6 +637,12 @@ class Listitem(object):
         self.is_folder = is_folder = kwargs.pop("is_folder", self.is_folder)
         self.is_playable = kwargs.pop("is_playable", not is_folder)
         if callback in dispatcher.registered_routes:
+            callback = dispatcher.registered_routes[callback].callback
+
+        # Handle case where callback is a full path to a callback function (i.e. "/resources/lib/foo/boo/")
+        # but not registered yet because in another python file that the current one
+        elif not isinstance(callback, types.FunctionType) and self.is_folder:
+            dispatcher.get_route(callback)
             callback = dispatcher.registered_routes[callback].callback
 
         self.path = callback


### PR DESCRIPTION
Hi @willforde,

This PR fix the error describe here: https://github.com/willforde/script.module.codequick/issues/33#issuecomment-602243034

## How to reproduce the error

* Create two python files `main.py` and `other.py`
* In `main.py` DO NOT import `other.py`
* In `root` function of `main.py` add one item like that:

```python
item = Listitem()
item.label = "Foo item"
item.set_callback('/other/foo/', is_folder=True)
return item
```

* In Kodi, when you press enter on "Foo item" you will get `CGUIMediaWindow::GetDirectory(/other/foo/) failed` error

Of course, feel free to fix this issue in another way if needed. thank you! 😉 

cc: @wwark