### PR TITLE
requests 2.29+ compatibility

### DIFF
--- a/script.module.codequick/addon.xml
+++ b/script.module.codequick/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="1.0.2">
     <requires>
-        <import addon="xbmc.python" version="2.25.0"/>
+        <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.youtube.dl" version="19.912.1"/>
         <import addon="script.module.htmlement" version="1.0.0"/>
         <import addon="script.module.requests" version="2.22.0"/>

--- a/script.module.codequick/lib/urlquick.py
+++ b/script.module.codequick/lib/urlquick.py
@@ -60,7 +60,6 @@ except ImportError:
 # Third Party
 from htmlement import HTMLement
 from requests.structures import CaseInsensitiveDict
-from requests.adapters import HTTPResponse
 from requests import adapters
 from requests import *
 import requests


### PR DESCRIPTION
This commit removes HTTPResponse from `requests.adapters` https://github.com/psf/requests/commit/26bea1e498d6e234fbc9ce8e07c0389bac73810b

As kodi just released the addon requests 2.31, urlquick is broken and this fix seems to work with this last version.